### PR TITLE
fix: Se inhabilita copiar plantilla

### DIFF
--- a/src/app/pages/plantillas/plantillas.component.ts
+++ b/src/app/pages/plantillas/plantillas.component.ts
@@ -84,10 +84,10 @@ export class PlantillasComponent implements OnInit {
             name: 'editar',
             title: '<em class="material-icons" title="Editar plantilla">edit</em>',
           },
-          {
-            name: 'copiar',
-            title: '<em class="material-icons" title="Copiar plantilla">file_copy</em>',
-          },
+          // {
+          //   name: 'copiar',
+          //   title: '<em class="material-icons" title="Copiar plantilla">file_copy</em>',
+          // },
           {
             name: 'borrar',
             title: '<em class="material-icons" title="Eliminar plantilla">delete</em>',


### PR DESCRIPTION
Se inhabilita temporalmente el boton copiar plantilla debido a la existencia de todas las plantillas posibles y evitar posible aumento de casos de soporte por el error arrojado. 