### PR TITLE
Fix validacion año vinculacion-expedicion con año vigencia

### DIFF
--- a/src/app/pages/admin-resoluciones/expedir-cancelacion/expedir-cancelacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-cancelacion/expedir-cancelacion.component.ts
@@ -92,8 +92,8 @@ export class ExpedirCancelacionComponent implements OnInit {
   cancelarContrato(): void {
     this.asignarValoresDefecto();
     if (this.resolucionActual.FechaExpedicion && this.contratoCanceladoBase.MotivoCancelacion) {
-      let regexAnio = /\b\d{4}\b/
-      let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
+      const fechaExpedicion = new Date(this.resolucionActual.FechaExpedicion)
+      const anioExpedicion = fechaExpedicion.getFullYear()
       anioExpedicion != this.resolucionActual.Vigencia ?
         this.popUp.warning("Fecha de expedición no coincide con vigencia") :
         this.confirmarExpedir()

--- a/src/app/pages/admin-resoluciones/expedir-cancelacion/expedir-cancelacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-cancelacion/expedir-cancelacion.component.ts
@@ -92,19 +92,27 @@ export class ExpedirCancelacionComponent implements OnInit {
   cancelarContrato(): void {
     this.asignarValoresDefecto();
     if (this.resolucionActual.FechaExpedicion && this.contratoCanceladoBase.MotivoCancelacion) {
-      this.popUp.confirmarExpedicion(
-        '¿Expedir la resolución?',
-        '¿Está seguro que desea expedir la resolución?',
-        this.resolucion,
-        this.contratados.length
-      ).then((result) => {
-        if (result.isConfirmed) {
-          this.expedirCancelar();
-        }
-      });
+      let regexAnio = /\b\d{4}\b/
+      let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
+      anioExpedicion != this.resolucionActual.Vigencia ?
+        this.popUp.warning("Fecha de expedición no coincide con vigencia") :
+        this.confirmarExpedir()
     } else {
       this.popUp.warning('Complete todos Los campos');
     }
+  }
+
+  confirmarExpedir() {
+    this.popUp.confirmarExpedicion(
+      '¿Expedir la resolución?',
+      '¿Está seguro que desea expedir la resolución?',
+      this.resolucion,
+      this.contratados.length
+    ).then((result) => {
+      if (result.isConfirmed) {
+        this.expedirCancelar();
+      }
+    });
   }
 
   expedirCancelar(): void {

--- a/src/app/pages/admin-resoluciones/expedir-modificacion/expedir-modificacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-modificacion/expedir-modificacion.component.ts
@@ -125,8 +125,8 @@ export class ExpedirModificacionComponent implements OnInit {
       this.Contrato.ObjetoContrato = 'Docente de Vinculación Especial - Medio Tiempo Ocasional (MTO) - Tiempo Completo Ocasional (TCO)';
     }
     if (this.resolucionActual.FechaExpedicion) {
-      let regexAnio = /\b\d{4}\b/
-      let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
+      const fechaExpedicion = new Date(this.resolucionActual.FechaExpedicion)
+      const anioExpedicion = fechaExpedicion.getFullYear()
       anioExpedicion != this.resolucionActual.Vigencia ?
         this.popUp.warning("Fecha de expedición no coincide con vigencia") :
         this.confirmarExpedir()

--- a/src/app/pages/admin-resoluciones/expedir-modificacion/expedir-modificacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-modificacion/expedir-modificacion.component.ts
@@ -125,18 +125,26 @@ export class ExpedirModificacionComponent implements OnInit {
       this.Contrato.ObjetoContrato = 'Docente de Vinculación Especial - Medio Tiempo Ocasional (MTO) - Tiempo Completo Ocasional (TCO)';
     }
     if (this.resolucionActual.FechaExpedicion) {
-      this.popUp.confirmarExpedicion(
-        '¿Expedir la resolución?',
-        '¿Está seguro que desea expedir la resolución?',
-        this.resolucion,
-      ).then((result) => {
-        if (result.isConfirmed) {
-          this.guardarContratos();
-        }
-      });
+      let regexAnio = /\b\d{4}\b/
+      let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
+      anioExpedicion != this.resolucionActual.Vigencia ?
+        this.popUp.warning("Fecha de expedición no coincide con vigencia") :
+        this.confirmarExpedir()
     } else {
       this.popUp.warning('Complete los campos');
     }
+  }
+
+  confirmarExpedir() {
+    this.popUp.confirmarExpedicion(
+      '¿Expedir la resolución?',
+      '¿Está seguro que desea expedir la resolución?',
+      this.resolucion,
+    ).then((result) => {
+      if (result.isConfirmed) {
+        this.guardarContratos();
+      }
+    });
   }
 
   guardarContratos(): void {

--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
@@ -126,7 +126,7 @@ export class ExpedirVinculacionComponent implements OnInit {
       anioInicio != this.resolucion.Vigencia ?
         this.popUp.error("Periodo de vincualción no coincide con vigencia") :
         anioExpedicion != this.resolucion.Vigencia ?
-          this.popUp.error("Fecha de expedición no coincide con vigencia") :
+          this.popUp.warning("Fecha de expedición no coincide con vigencia") :
           this.expedir()
 
     } else {

--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
@@ -108,9 +108,10 @@ export class ExpedirVinculacionComponent implements OnInit {
   }
 
   realizarContrato(): void {
-    let regexAnio = /\b\d{4}\b/
-    let anioInicio = parseInt(this.acta.FechaInicio.toString().match(regexAnio)[0])
-    let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
+    const fechaInicioVinculacion = new Date(this.acta.FechaInicio)
+    const fechaExpedicion = new Date(this.resolucionActual.FechaExpedicion)
+    const anioInicio = fechaInicioVinculacion.getFullYear()
+    const anioExpedicion = fechaExpedicion.getFullYear()
     if (this.resolucionVinculacion.Dedicacion === 'HCH') {
       this.Contrato.TipoContrato = { Id: 3 };
       this.Contrato.ObjetoContrato = 'Docente de Vinculación Especial - Honorarios';

--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
@@ -124,7 +124,7 @@ export class ExpedirVinculacionComponent implements OnInit {
 
     if (this.resolucionActual.FechaExpedicion && this.acta.FechaInicio) {
       anioInicio != this.resolucion.Vigencia ?
-        this.popUp.error("Periodo de vincualción no coincide con vigencia") :
+        this.popUp.warning("Periodo de vincualción no coincide con vigencia") :
         anioExpedicion != this.resolucion.Vigencia ?
           this.popUp.warning("Fecha de expedición no coincide con vigencia") :
           this.expedir()

--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.ts
@@ -108,6 +108,9 @@ export class ExpedirVinculacionComponent implements OnInit {
   }
 
   realizarContrato(): void {
+    let regexAnio = /\b\d{4}\b/
+    let anioInicio = parseInt(this.acta.FechaInicio.toString().match(regexAnio)[0])
+    let anioExpedicion = parseInt(this.resolucionActual.FechaExpedicion.toString().match(regexAnio)[0])
     if (this.resolucionVinculacion.Dedicacion === 'HCH') {
       this.Contrato.TipoContrato = { Id: 3 };
       this.Contrato.ObjetoContrato = 'Docente de Vinculación Especial - Honorarios';
@@ -118,19 +121,29 @@ export class ExpedirVinculacionComponent implements OnInit {
       this.Contrato.TipoContrato = { Id: 18 };
       this.Contrato.ObjetoContrato = 'Docente de Vinculación Especial - Medio Tiempo Ocasional (MTO) - Tiempo Completo Ocasional (TCO)';
     }
+
     if (this.resolucionActual.FechaExpedicion && this.acta.FechaInicio) {
-      this.popUp.confirmarExpedicion(
-        '¿Expedir la resolución?',
-        '¿Está seguro de que desea expedir la resolución?',
-        this.resolucion,
-      ).then(result => {
-        if (result.isConfirmed) {
-          this.guardarContratos();
-        }
-      });
+      anioInicio != this.resolucion.Vigencia ?
+        this.popUp.error("Periodo de vincualción no coincide con vigencia") :
+        anioExpedicion != this.resolucion.Vigencia ?
+          this.popUp.error("Fecha de expedición no coincide con vigencia") :
+          this.expedir()
+
     } else {
       this.popUp.warning('Complete los campos');
     }
+  }
+
+  expedir(): void {
+    this.popUp.confirmarExpedicion(
+      '¿Expedir la resolución?',
+      '¿Está seguro de que desea expedir la resolución?',
+      this.resolucion,
+    ).then(result => {
+      if (result.isConfirmed) {
+        this.guardarContratos();
+      }
+    });
   }
 
   guardarContratos(): void {


### PR DESCRIPTION
Se hace validacion en el cliente para alertar al usuario de que el año de vinculacion y el año de expedicion deben coincidir con la vigencia.

1.) Fechas de vinculacion de diferente vigencia
![image](https://github.com/udistrital/resoluciones_cliente_v2/assets/49110446/cbeed42b-3e58-4502-954a-07b676aa30a8)

2.) Fecha de expedicion con diferente vigencia
![image](https://github.com/udistrital/resoluciones_cliente_v2/assets/49110446/b24c250a-79da-4187-941d-70fe0dcbf7d9)
