### PR TITLE
feat: #196 tooltip informacion fecha inicio

### DIFF
--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.html
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.html
@@ -32,12 +32,17 @@
     </div>
     <div class="section">
         <h2 class="section-title">Periodo de Vinculación</h2>
-        <mat-form-field class="form-field-date">
-            <mat-label>Fecha de inicio válida</mat-label>
-            <input matInput [matDatepicker]="picker" name="fechaInicio" [(ngModel)]="acta.FechaInicio" (dateChange)="cambioFechaResolucion()">
-            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-            <mat-datepicker #picker></mat-datepicker>
-        </mat-form-field>
+        <div class="tooltip-container">
+            <mat-form-field class="form-field-date"
+                matTooltip="Por favor, no seleccionar la fecha dada por resolución. Seleccionar el sábado inmediatamente anterior para una correcta preliquidación."
+                matTooltipClass="mat-tooltip">
+                <mat-label>Fecha de inicio válida</mat-label>
+                <input matInput [matDatepicker]="picker" name="fechaInicio" [(ngModel)]="acta.FechaInicio"
+                    (dateChange)="cambioFechaResolucion()">
+                <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+                <mat-datepicker #picker></mat-datepicker>
+            </mat-form-field>
+        </div>  
         <mat-form-field class="form-field-date">
             <mat-label>Fecha fin</mat-label>
             <input matInput [matDatepicker]="picker2" name="fechaFin" [(ngModel)]="resolucionActual.FechaFin">

--- a/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.scss
+++ b/src/app/pages/admin-resoluciones/expedir-vinculacion/expedir-vinculacion.component.scss
@@ -55,6 +55,20 @@
     align-items: flex-start;
 }
 
+::ng-deep .mat-tooltip {
+    font-size: 1em;
+    text-align: justify;
+    background-color: var(--primary);
+    position: absolute;
+    width: 200px;
+}
+
+.tooltip-container {
+    display: flex;
+    position: relative;
+    align-items: center;
+}
+
 @media screen and (max-width: 1024px) {
     .form-field-column {
         width: 100%;

--- a/src/app/pages/pages.module.ts
+++ b/src/app/pages/pages.module.ts
@@ -7,6 +7,7 @@ import { PagesComponent } from './pages.component';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RequestManager } from './services/requestManager';
 
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatCardModule } from '@angular/material/card';
@@ -105,7 +106,8 @@ const materialModules = [
   MatRadioModule,
   MatProgressBarModule,
   MatProgressSpinnerModule,
-  MatSlideToggleModule
+  MatSlideToggleModule,
+  MatTooltipModule
 ];
 @NgModule({
   declarations: [


### PR DESCRIPTION
#196 Inclusion de aviso al seleccionar fecha inicio
Se genera el siguiente recuadro con la sugerencia al seleccionar la fecha inicio al momento de realizar la expedicion de una resolución de vinculación:
![Screenshot_20240726_203511](https://github.com/user-attachments/assets/6b0a69b2-288b-44e4-acff-855eed54a29d)
